### PR TITLE
Prerequisite for Ember CLI Addon projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ npm install --save broccoli-compass-compiler
 
 ```javascript
 var compileCompass = require('broccoli-compass-compiler');
-var tree = compileCompass(['app/styles'], {
+var tree = compileCompass(['app/styles'], 'addon.scss', 'path/to/output.css' {
   outputStyle: 'compressed'
 });
 ```

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -1,13 +1,14 @@
 var CachingWriter = require('broccoli-caching-writer');
 var Compass = require('compass-compile');
 var merge = require('merge');
+var includePathSearcher = require('include-path-searcher');
 
 CompassCompiler.prototype = Object.create(CachingWriter.prototype);
 CompassCompiler.prototype.constructor = CompassCompiler;
 
-function CompassCompiler(inputTrees, options) {
+function CompassCompiler(inputTrees, inputFile, outputFile, options) {
   options = options || {};
-  if (!(this instanceof CompassCompiler)) { return new CompassCompiler(inputTrees, options); }
+  if (!(this instanceof CompassCompiler)) { return new CompassCompiler(inputTrees, inputFile, outputFile, options); }
   if (!Array.isArray(inputTrees)) { throw new Error('Expected array for first argument - did you mean [tree] instead of tree?'); }
 
   if (options.importPath && Array.isArray(options.importPath) && options.importPath.length > 0) {
@@ -28,6 +29,8 @@ function CompassCompiler(inputTrees, options) {
     }
   };
 
+  this.inputFile = inputFile;
+  this.outputFile = outputFile;
   this.inputTrees = inputTrees;
   this.options = options;
   this.compass = new Compass();

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -1,6 +1,9 @@
 var CachingWriter = require('broccoli-caching-writer');
 var Compass = require('compass-compile');
 var merge = require('merge');
+var fs = require('fs');
+var path = require('path');
+var mkdirp = require('mkdirp');
 var includePathSearcher = require('include-path-searcher');
 
 CompassCompiler.prototype = Object.create(CachingWriter.prototype);
@@ -51,7 +54,18 @@ CompassCompiler.prototype.getOptions = function() {
 
 CompassCompiler.prototype.build = function() {
   var compassOptions = this.getOptions();
-  return this.compass.compile(compassOptions);
+  var inputExtension = path.extname(this.inputFile);
+  var filename = path.basename(this.inputFile, inputExtension);
+  var outputPaths = compassOptions.outputPaths;
+  var outputExtension = path.extname(outputPaths[filename]);
+  var outputFile = path.join(this.outputPath, filename + outputExtension);
+  var destFile = path.join(this.outputPath, outputPaths[filename]);
+  var destDir = path.dirname(destFile);
+
+  return this.compass.compile(compassOptions).then(function(output) {
+    mkdirp.sync(destDir);
+    fs.renameSync(outputFile, destFile);
+  }.bind(this));
 };
 
 module.exports = CompassCompiler;

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -21,8 +21,12 @@ function CompassCompiler(inputTrees, inputFile, outputFile, options) {
 
   this.defaultOptions = {
     importPath: [],
-    getSassDir: function(inputTrees) {
-      return inputTrees[0];
+    getSassDir: function(inputTrees, inputPaths) {
+      // Check the input paths for the existence of the input file
+      var file = includePathSearcher.findFileSync(inputFile, inputPaths);
+
+      // Compass compiler only needs the directory
+      return path.dirname(file);
     },
     getCssDir: function(outputPath) {
       return outputPath;

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -22,8 +22,19 @@ function CompassCompiler(inputTrees, inputFile, outputFile, options) {
     annotation: options.annotation
   });
 
-  this.defaultOptions = {
-    importPath: [],
+  this.inputFile = inputFile;
+  this.outputFile = outputFile;
+  this.inputTrees = inputTrees;
+  this.options = options;
+  this.compass = new Compass();
+}
+
+CompassCompiler.prototype.getOptions = function() {
+  var inputPaths = this.inputPaths.slice();
+  var inputFile = this.inputFile;
+
+  var defaultOptions = {
+    importPath: inputPaths,
     getSassDir: function(inputTrees, inputPaths) {
       // Check the input paths for the existence of the input file
       var file = includePathSearcher.findFileSync(inputFile, inputPaths);
@@ -34,17 +45,10 @@ function CompassCompiler(inputTrees, inputFile, outputFile, options) {
     getCssDir: function(outputPath) {
       return outputPath;
     }
-  };
+  }
 
-  this.inputFile = inputFile;
-  this.outputFile = outputFile;
-  this.inputTrees = inputTrees;
-  this.options = options;
-  this.compass = new Compass();
-}
+  var compassOptions = merge({}, defaultOptions, this.options);
 
-CompassCompiler.prototype.getOptions = function() {
-  var compassOptions = merge({}, this.defaultOptions, this.options);
   compassOptions.sassDir = compassOptions.getSassDir(this.inputTrees, this.inputPaths);
   compassOptions.cssDir = compassOptions.getCssDir(this.outputPath);
   delete compassOptions.getSassDir;

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "broccoli-caching-writer": "^2.0.1",
     "compass-compile": "0.0.1",
     "include-path-searcher": "^0.1.0",
-    "merge": "^1.2.0"
+    "merge": "^1.2.0",
+    "mkdirp": "^0.5.1"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "broccoli-caching-writer": "^2.0.1",
     "compass-compile": "0.0.1",
+    "include-path-searcher": "^0.1.0",
     "merge": "^1.2.0"
   },
   "repository": {


### PR DESCRIPTION
This PR adds support for Ember CLI Addon projects.

It is a prerequisite to fixing: https://github.com/quaertym/ember-cli-compass-compiler/issues/47

**IMPORTANT:** This is a backwards breaking change as it adds two new arguments to the constructor. I highly recommend updating the major version number as per [SEMVER 2.0](http://semver.org/) specs on the next release.
## CHANGELOG:
- Updates constructor method signature:
  ##### Old:
  
  ``` javascript
  function CompassCompiler(inputTrees, options)
  ```
  ##### New:
  
  ``` javascript
  function CompassCompiler(inputTrees, inputFile, outputFile, options)
  ```
- Fixes a bug which prevented stylesheets in `addon/styles` from compiling properly in Ember CLI Addon projects
  
  Updates `getSassDir(inputTrees, inputPaths)` function which previously only returned `inputTrees[0]` to actually check for input file in the input paths and use that for sassDir option.
- Fixes a bug which prevented compiled Compass output files from being copied properly to `/dist` directory in Ember CLI Addon projects
  
  Updates `CompassCompiler.prototype.build` function to rename and move the files properly for Ember CLI Addon projects. This guarantees that `addon/styles/addon.scss` (or `addon.sass`) gets compiled properly to `dist/vendor.css` and `test/dummy/app/styles/app.scss` to compile properly to `dist/dummy.css`.
